### PR TITLE
fix: diagnostics field should not be omited

### DIFF
--- a/go-lsp/lsp/defines/protocol.go
+++ b/go-lsp/lsp/defines/protocol.go
@@ -933,7 +933,7 @@ type PublishDiagnosticsParams struct {
 	Version *int `json:"version,omitempty"`
 
 	// An array of diagnostic information items.
-	Diagnostics []Diagnostic `json:"diagnostics,omitempty"`
+	Diagnostics []Diagnostic `json:"diagnostics"`
 }
 
 /**


### PR DESCRIPTION
Neovim lsp implementation requires `diagnostics` field to be present, even when no diagnostics are shown.

resolves #11