### PR TITLE
Add support for symbol hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ if you use vscode, see [vscode-extension/README.md](./vscode-extension/README.md
 ## features
 
 1. Parsing document symbols
-2. Go to definition
-3. Format file with clang-format
-4. Code completion
-5. Jump from protobuf's cpp header to proto define (only global message and enum)
+1. Go to definition
+1. Symbol definition on hover
+1. Format file with clang-format
+1. Code completion
+1. Jump from protobuf's cpp header to proto define (only global message and enum)

--- a/components/hover.go
+++ b/components/hover.go
@@ -1,0 +1,270 @@
+package components
+
+import (
+	"bytes"
+	"context"
+	"pls/proto/parser"
+	"strings"
+	"text/template"
+
+	"github.com/TobiasYin/go-lsp/lsp/defines"
+	"github.com/emicklei/proto"
+)
+
+var hoverTmpl *template.Template
+
+// Parsing templates once on server start
+func init() {
+	hoverTmpl = template.New("hover")
+	hoverTmpl = hoverTmpl.Funcs(getCustomFuncs(hoverTmpl))
+	hoverTmpl = template.Must(hoverTmpl.Parse(hoverTemplate))
+
+	messageTmpl := template.New("message")
+	messageTmpl = messageTmpl.Funcs(getCustomFuncs(hoverTmpl))
+	messageTmpl = template.Must(hoverTmpl.Parse(messageTemplate))
+
+	enumTmpl := template.New("enum")
+	enumTmpl = enumTmpl.Funcs(getCustomFuncs(hoverTmpl))
+	enumTmpl = template.Must(hoverTmpl.Parse(enumTemplate))
+}
+
+func Hover(ctx context.Context, req *defines.HoverParams) (result *defines.Hover, err error) {
+
+	symbols, err := findSymbolDefinition(ctx, &req.TextDocumentPositionParams)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(symbols) == 0 {
+		return nil, ErrSymbolNotFound
+	}
+
+	result = &defines.Hover{
+		Contents: defines.MarkupContent{
+			Kind:  defines.MarkupKindMarkdown,
+			Value: formatHover(symbols[0]),
+		},
+	}
+
+	return result, nil
+}
+
+func formatHover(symbol SymbolDefinition) string {
+
+	var hoverData hoverData
+
+	switch symbol.Type {
+	case DefinitionTypeEnum:
+		hoverData.Enum = prepareEnumData(symbol.Enum)
+	case DefinitionTypeMessage:
+		hoverData.Message = prepareMessageData(symbol.Message)
+	default:
+		return ""
+	}
+
+	buffer := bytes.NewBuffer(nil)
+	err := hoverTmpl.Execute(buffer, hoverData)
+	if err != nil {
+		return err.Error()
+	}
+
+	return buffer.String()
+}
+
+const hoverTemplate = "```proto" + `
+{{- if .Message }}
+{{- templateWithIndent "message" .Message 0 }}
+{{- end }}
+{{- if .Enum }}
+{{- templateWithIndent "enum" .Enum 0 }}
+{{- end }}
+` + "```"
+
+type hoverData struct {
+	Message *messageData
+	Enum    *enumData
+}
+
+const enumTemplate = `{{- define "enum" }}
+{{- range .Comments }}
+{{ . }}
+{{- end }}
+enum {{ .Name }} {
+	{{- range .Items }}
+	{{- range .Comments }}
+	{{ . }}
+	{{- end }}
+	{{ .Name }} = {{ .Value }}; {{ if .InlineComment }}{{ .InlineComment }}{{end}}
+	{{- end }}
+}
+{{- end }}`
+
+type enumData struct {
+	Comments []string
+	Name     string
+	Items    []enumItem
+}
+
+type enumItem struct {
+	Comments      []string
+	Name          string
+	Value         int
+	InlineComment string
+}
+
+type enumFieldVisitor struct {
+	proto.NoopVisitor
+	visitFunc func(*proto.EnumField)
+}
+
+func (v *enumFieldVisitor) VisitEnumField(ef *proto.EnumField) {
+	v.visitFunc(ef)
+}
+
+func prepareEnumData(enum parser.Enum) *enumData {
+
+	data := enumData{
+		Name:  enum.Protobuf().Name,
+		Items: []enumItem{},
+	}
+
+	if enum.Protobuf().Comment != nil {
+		data.Comments = formatComments(enum.Protobuf().Comment.Lines)
+	}
+
+	for _, item := range enum.Protobuf().Elements {
+		item.Accept(&enumFieldVisitor{visitFunc: func(ef *proto.EnumField) {
+
+			enumItem := enumItem{
+				Name:  ef.Name,
+				Value: ef.Integer,
+			}
+
+			if ef.Comment != nil {
+				enumItem.Comments = formatComments(ef.Comment.Lines)
+			}
+
+			if ef.InlineComment != nil && len(ef.InlineComment.Lines) != 0 {
+				enumItem.InlineComment = formatComments(ef.InlineComment.Lines[0:1])[0]
+			}
+
+			data.Items = append(data.Items, enumItem)
+		}})
+	}
+
+	return &data
+}
+
+const messageTemplate = `{{- define "message" }}
+{{- range .Comments }}
+{{ . }}
+{{- end }}
+message {{ .Name }} {
+{{- range .NestedEnums }}
+	{{- templateWithIndent "enum" . 1 }}
+{{- end }}
+{{- range .NestedMessages }}
+	{{- templateWithIndent "message" . 1 }}
+{{- end }}
+{{- range .Fields -}}
+	{{- range .Comments }}
+	{{ . }}
+	{{- end }}
+	{{.Optional}}{{.Repeated}}{{.Type}} {{.Name}} = {{.ProtoSequence}};{{ if .InlineComment }} // {{.InlineComment }}{{ end }}
+{{- end }}
+}
+{{- end }}`
+
+type messageData struct {
+	Comments       []string
+	Name           string
+	Fields         []field
+	NestedEnums    []*enumData
+	NestedMessages []*messageData
+}
+
+type field struct {
+	Comments      []string
+	Repeated      string
+	Optional      string
+	Type          string
+	Name          string
+	ProtoSequence int
+	InlineComment string
+}
+
+func prepareMessageData(message parser.Message) *messageData {
+
+	data := messageData{
+		Name: message.Protobuf().Name,
+	}
+
+	if message.Protobuf().Comment != nil {
+		data.Comments = formatComments(message.Protobuf().Comment.Lines)
+	}
+
+	for _, nestedMsg := range message.NestedMessages() {
+		data.NestedMessages = append(data.NestedMessages, prepareMessageData(nestedMsg))
+	}
+
+	for _, nestedEnum := range message.NestedEnums() {
+		data.NestedEnums = append(data.NestedEnums, prepareEnumData(nestedEnum))
+	}
+
+	for _, item := range message.Fields() {
+
+		var field field
+
+		if item.ProtoField.Comment != nil {
+			field.Comments = formatComments(item.ProtoField.Comment.Lines)
+		}
+
+		if item.ProtoField.Optional {
+			field.Optional = "optional "
+		}
+		if item.ProtoField.Repeated {
+			field.Repeated = "repeated "
+		}
+
+		field.Type = item.ProtoField.Type
+		field.Name = item.ProtoField.Name
+		field.ProtoSequence = item.ProtoField.Sequence
+
+		if item.ProtoField.InlineComment != nil {
+			field.InlineComment = formatComments(item.ProtoField.InlineComment.Lines[0:1])[0]
+		}
+		data.Fields = append(data.Fields, field)
+	}
+
+	return &data
+}
+
+func getCustomFuncs(parent *template.Template) template.FuncMap {
+	return template.FuncMap{
+		"templateWithIndent": func(name string, data interface{}, indent int) (string, error) {
+			buf := bytes.NewBuffer(nil)
+			if err := parent.ExecuteTemplate(buf, name, data); err != nil {
+				return "", err
+			}
+
+			return indentText(buf.String(), indent), nil
+		},
+	}
+}
+
+func indentText(text string, level int) string {
+	indent := strings.Repeat("\t", level)
+	return indent + strings.ReplaceAll(text, "\n", "\n"+indent)
+}
+
+func formatComments(lines []string) []string {
+	if len(lines) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(lines))
+	for _, item := range lines {
+		out = append(out, "//"+item)
+	}
+	return out
+}

--- a/components/jump_definition.go
+++ b/components/jump_definition.go
@@ -278,21 +278,15 @@ func getWord(line string, idx int, includeDot bool) string {
 	isWordChar := func(ch byte) bool {
 		return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || (ch == '.' && includeDot)
 	}
-	ll := l
-	for ll >= 0 {
-		if !isWordChar(line[ll]) {
-			break
-		}
-		ll--
+
+	for l >= 0 && isWordChar(line[l]) {
+		l--
 	}
-	if ll != l {
-		ll = ll + 1
+	if l != idx {
+		l += 1
 	}
-	l = ll
-	for r < len(line) {
-		if !isWordChar(line[r]) {
-			break
-		}
+
+	for r < len(line) && isWordChar(line[r]) {
 		r++
 	}
 	return line[l:r]

--- a/components/jump_definition_test.go
+++ b/components/jump_definition_test.go
@@ -1,0 +1,71 @@
+package components
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_getWord(t *testing.T) {
+	type args struct {
+		line       string
+		idx        int
+		includeDot bool
+	}
+	tests := []struct {
+		args args
+		want string
+	}{
+		{
+			args: args{
+				// cursor is right here                            |
+				line:       "rpc MethodName(SearchDashboardReq) returns (SearchDashboardResp) {",
+				idx:        38,
+				includeDot: false,
+			},
+			want: "returns",
+		},
+		{
+			args: args{
+				// cursor is right here           |
+				line:       "rpc MethodName(SearchDashboardReq) returns (SearchDashboardResp) {",
+				idx:        21,
+				includeDot: false,
+			},
+			want: "SearchDashboardReq",
+		},
+		{
+			args: args{
+				// cursor is right here                        |
+				line:       "rpc MethodName(SearchDashboardReq) returns (SearchDashboardResp) {",
+				idx:        34,
+				includeDot: false,
+			},
+			want: "",
+		},
+		{
+			args: args{
+				// cursor is right here                                           |
+				line:       "rpc MethodName(SearchDashboardReq) returns (google.protobuf.Empty) {",
+				idx:        53,
+				includeDot: false,
+			},
+			want: "protobuf",
+		},
+		{
+			args: args{
+				// cursor is right here                                           |
+				line:       "rpc MethodName(SearchDashboardReq) returns (google.protobuf.Empty) {",
+				idx:        53,
+				includeDot: true,
+			},
+			want: "google.protobuf.Empty",
+		},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			if got := getWord(tt.args.line, tt.args.idx, tt.args.includeDot); got != tt.want {
+				t.Errorf("getWord() = '%v', want '%v'", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -56,5 +56,6 @@ func main() {
 	server.OnDefinition(components.JumpDefine)
 	server.OnDocumentFormatting(components.Format)
 	server.OnCompletion(components.Completion)
+	server.OnHover(components.Hover)
 	server.Run()
 }


### PR DESCRIPTION
This pr slightly refactors `jump_definition.go`, to allow reuse of symbol searching algorithm, and uses it to find symbol for hover generation, thus ensuring that "go to definition" and "hover" would operate on the same symbol.

Hover doc generation is implemented through `text/template` package, and supports nested messages and enums.

Hover example is shown in a picture below

![image](https://github.com/lasorda/protobuf-language-server/assets/38500943/d59995ce-671a-4b71-9a45-6f706a0b0bcb)
