### PR TITLE
Improve configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Using [coc.nvim](https://github.com/neoclide/coc.nvim), add it to `:CocConfig`
         "proto" :{
             "command": "protobuf-language-server",
             "filetypes": ["proto", "cpp"]
+            "settings": {
+                "additional-proto-dirs": [ ]
+            }
         }
     }
 ```
@@ -41,7 +44,13 @@ configs.protobuf-language-server = {
         filetypes = { 'proto', 'cpp' },
         root_fir = util.root_pattern('.git'),
         single_file_support = true,
-        settings = {},
+        settings = {
+            ["additional-proto-dirs"] = [
+                -- path to additional protobuf directories
+                -- "vendor",
+                -- "third_party",
+            ]
+        },
     }
 }
 

--- a/components/completion.go
+++ b/components/completion.go
@@ -83,7 +83,7 @@ func GetImportedPackages(ctx context.Context, proto_file view.ProtoFile) (res []
 		default:
 		}
 
-		import_uri, err := view.GetDocumentUriFromImportPath(proto_file.URI(), im.ProtoImport.Filename)
+		import_uri, err := view.ViewManager.GetDocumentUriFromImportPath(proto_file.URI(), im.ProtoImport.Filename)
 		if err != nil {
 			continue
 		}
@@ -123,7 +123,7 @@ func CompletionInPackage(ctx context.Context, file view.ProtoFile, packageName s
 		default:
 		}
 
-		import_uri, err := view.GetDocumentUriFromImportPath(file.URI(), im.ProtoImport.Filename)
+		import_uri, err := view.ViewManager.GetDocumentUriFromImportPath(file.URI(), im.ProtoImport.Filename)
 		if err != nil {
 			continue
 		}

--- a/components/jump_definition.go
+++ b/components/jump_definition.go
@@ -183,7 +183,7 @@ func searchImport(proto view.ProtoFile, package_name, my_package, word, kind str
 			continue
 		}
 
-		import_uri, err := view.GetDocumentUriFromImportPath(proto.URI(), im.ProtoImport.Filename)
+		import_uri, err := view.ViewManager.GetDocumentUriFromImportPath(proto.URI(), im.ProtoImport.Filename)
 		if err != nil {
 			continue
 		}
@@ -236,7 +236,7 @@ func jumpImport(ctx context.Context, position *defines.TextDocumentPositionParam
 	if pos == nil {
 		return nil, fmt.Errorf("import match failed")
 	}
-	import_uri, err := view.GetDocumentUriFromImportPath(position.TextDocument.Uri, line_str[pos[0]+1:pos[1]-1])
+	import_uri, err := view.ViewManager.GetDocumentUriFromImportPath(position.TextDocument.Uri, line_str[pos[0]+1:pos[1]-1])
 	if err != nil {
 		return nil, err
 	}

--- a/go-lsp/logs/log.go
+++ b/go-lsp/logs/log.go
@@ -1,11 +1,52 @@
 package logs
 
-import "log"
+import (
+	"log"
+	"os"
+	"path"
+)
+
+const (
+	logFileName        = ".protobuf-language-server.log"
+	logBackUpExtension = ".bak"
+)
 
 var logger *log.Logger
 
-func Init(l *log.Logger) {
+// Init initializes logger with a logPath
+//
+// If logPath is nil then log file is created in os.UserHomeDir
+func Init(logPath *string) {
+	if logPath == nil || *logPath == "" {
+		logger = stdErrLogger()
+		return
+	}
+	l, err := fileLogger(*logPath)
+	if err != nil {
+		panic("error initializing file logger at " + *logPath)
+	}
 	logger = l
+}
+
+func stdErrLogger() *log.Logger {
+	return log.New(os.Stderr, "", 0)
+}
+
+func fileLogger(path string) (*log.Logger, error) {
+	if _, err := os.Stat(path); err == nil {
+		os.Rename(path, path+logBackUpExtension)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	logger = log.New(f, "", 0)
+	return logger, nil
+}
+
+func DefaultLogFilePath() string {
+	home, _ := os.UserHomeDir()
+	return path.Join(home, logFileName)
 }
 
 func Println(v ...interface{}) {

--- a/main.go
+++ b/main.go
@@ -12,11 +12,13 @@ import (
 )
 
 var (
+	address *string
 	logPath *string
 )
 
 func init() {
 	logPath = flag.String("logs", logs.DefaultLogFilePath(), "logs file path")
+	address = flag.String("listen", "", "address on which to listen for remote connections")
 }
 
 func main() {
@@ -27,6 +29,10 @@ func main() {
 		CompletionProvider: &defines.CompletionOptions{
 			TriggerCharacters: &[]string{"."},
 		},
+	}
+	if *address != "" {
+		config.Address = *address
+		config.Network = "tcp"
 	}
 
 	server := lsp.NewServer(config)

--- a/proto/view/fs/fs.go
+++ b/proto/view/fs/fs.go
@@ -1,0 +1,5 @@
+package fs
+
+type FS interface {
+	FileExists(path string) bool
+}

--- a/proto/view/fs/realfs.go
+++ b/proto/view/fs/realfs.go
@@ -1,0 +1,13 @@
+package fs
+
+import (
+	"os"
+)
+
+// Wrapps OS file methods in FS interface
+type RealFS struct{}
+
+func (r *RealFS) FileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/proto/view/mock_fs_test.go
+++ b/proto/view/mock_fs_test.go
@@ -1,0 +1,18 @@
+package view
+
+type MockFS struct {
+	ExistingFiles []string
+}
+
+func (m *MockFS) FileExists(path string) bool {
+	return contains(m.ExistingFiles, path)
+}
+
+func contains(items []string, x string) bool {
+	for _, item := range items {
+		if item == x {
+			return true
+		}
+	}
+	return false
+}

--- a/proto/view/settings.go
+++ b/proto/view/settings.go
@@ -1,0 +1,56 @@
+package view
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	additionalProtoDirsKey = "additional-proto-dirs"
+)
+
+type Settings struct {
+	AdditionalProtoDirs []string
+}
+
+var (
+	ErrRepackingSettings = errors.New("failed repacking settings")
+)
+
+func SettingsFromInterface(in interface{}) (*Settings, error) {
+	settingsMap, ok := in.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%w: settings should have a map[string]interface{} type", ErrRepackingSettings)
+	}
+
+	var settings Settings
+
+	if value, ok := settingsMap[additionalProtoDirsKey]; ok {
+		protoDirs, err := StringsSliceFromInterface(value)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s: key = %s", ErrRepackingSettings, err.Error(), additionalProtoDirsKey)
+		}
+		settings.AdditionalProtoDirs = protoDirs
+	}
+
+	return &settings, nil
+}
+
+func StringsSliceFromInterface(in interface{}) ([]string, error) {
+	interfaceSlice, ok := in.([]interface{})
+	if !ok {
+		return nil, errors.New("field should have a []interface{} type")
+	}
+
+	var result []string
+
+	for i, item := range interfaceSlice {
+		str, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("item [%d] should have a string type", i)
+		}
+		result = append(result, str)
+	}
+
+	return result, nil
+}

--- a/proto/view/view.go
+++ b/proto/view/view.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha1"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -21,6 +22,7 @@ import (
 	"go.lsp.dev/uri"
 
 	"github.com/lasorda/protobuf-language-server/proto/parser"
+	"github.com/lasorda/protobuf-language-server/proto/view/fs"
 )
 
 type view struct {
@@ -36,7 +38,10 @@ type view struct {
 
 	pbHeaders map[defines.DocumentUri][]string
 	Server    *lsp.Server
+	fs        fs.FS
 }
+
+var ErrNotFound = errors.New("not found")
 
 func (v *view) GetFile(document_uri defines.DocumentUri) (ProtoFile, error) {
 	if f, ok := v.filesByURI[document_uri]; ok {
@@ -223,7 +228,7 @@ func (v *view) parseImportProto(document_uri defines.DocumentUri) {
 		return
 	}
 	for _, i := range proto_file.Proto().Imports() {
-		import_uri, err := GetDocumentUriFromImportPath(document_uri, i.ProtoImport.Filename)
+		import_uri, err := ViewManager.GetDocumentUriFromImportPath(document_uri, i.ProtoImport.Filename)
 		if err != nil {
 			logs.Printf("parse import err:%v", err)
 			continue
@@ -266,6 +271,7 @@ func newView() *view {
 		openFiles:   make(map[defines.DocumentUri]bool),
 		openFileMu:  &sync.RWMutex{},
 		pbHeaders:   make(map[defines.DocumentUri][]string),
+		fs:          &fs.RealFS{},
 	}
 }
 
@@ -280,18 +286,17 @@ func parseProto(document_uri defines.DocumentUri, data []byte) (proto parser.Pro
 	return proto, err
 }
 
-func GetDocumentUriFromImportPath(cwd defines.DocumentUri, import_name string) (defines.DocumentUri, error) {
+func (v *view) GetDocumentUriFromImportPath(cwd defines.DocumentUri, import_name string) (defines.DocumentUri, error) {
 	pos := path.Dir(uri.URI(cwd).Filename())
 	var res defines.DocumentUri
 	for path.Clean(pos) != "/" {
 		abs_name := path.Join(pos, import_name)
-		_, err := os.Stat(abs_name)
-		if err == nil {
+		if v.fs.FileExists(abs_name) {
 			return defines.DocumentUri(uri.New(path.Clean(abs_name))), nil
 		}
 		pos = path.Join(pos, "..")
 	}
-	return res, fmt.Errorf("import %v not found", import_name)
+	return res, fmt.Errorf("%w: import %s", ErrNotFound, import_name)
 }
 
 func toUtf8(iso8859_1_buf []byte) []byte {

--- a/proto/view/view_test.go
+++ b/proto/view/view_test.go
@@ -1,0 +1,58 @@
+package view
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lasorda/protobuf-language-server/go-lsp/lsp/defines"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_view_GetDocumentUriFromImportPath(t *testing.T) {
+	type args struct {
+	}
+	tests := []struct {
+		name          string
+		existingFiles []string
+		cwd           defines.DocumentUri
+		import_name   string
+		want          defines.DocumentUri
+		wantErr       error
+	}{
+		{
+			name: "import is found when it's base directory is inside project root",
+			existingFiles: []string{
+				"/project-dir/api/my-service.proto",
+				"/project-dir/google/protobuf/empty.proto",
+			},
+			cwd:         defines.DocumentUri("file:///project-dir/api/my-service.proto"),
+			import_name: "google/protobuf/empty.proto",
+
+			want:    defines.DocumentUri("file:///project-dir/google/protobuf/empty.proto"),
+			wantErr: nil,
+		},
+		{
+			name: "import is not found when it's in some sub-directory",
+			existingFiles: []string{
+				"/project-dir/api/my-service.proto",
+				"/project-dir/protobuf-dependencies/google/protobuf/empty.proto",
+			},
+			cwd:         defines.DocumentUri("file:///project-dir/api/my-service.proto"),
+			import_name: "google/protobuf/empty.proto",
+
+			want:    defines.DocumentUri(""),
+			wantErr: ErrNotFound,
+		},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			mockFS := &MockFS{ExistingFiles: tt.existingFiles}
+
+			v := &view{fs: mockFS}
+
+			got, err := v.GetDocumentUriFromImportPath(tt.cwd, tt.import_name)
+			require.ErrorIs(t, err, tt.wantErr)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
What i've done:
* Added ability to specify additional vendor directories to search through for symbol search via `settings` in lsp
* Added ability to start language server in remote mode via `-listen` flag (useful for debugging)
* Tidied up init and main functions, especially logger initialization
* Covered GetDocumentUriFromImportPath function with tests