### PR TITLE
feat: find references

### DIFF
--- a/components/jump_definition_test.go
+++ b/components/jump_definition_test.go
@@ -12,10 +12,12 @@ func Test_getWord(t *testing.T) {
 		includeDot bool
 	}
 	tests := []struct {
+		name string
 		args args
 		want string
 	}{
 		{
+			name: "word in middle of rpc line",
 			args: args{
 				// cursor is right here                            |
 				line:       "rpc MethodName(SearchDashboardReq) returns (SearchDashboardResp) {",
@@ -25,6 +27,7 @@ func Test_getWord(t *testing.T) {
 			want: "returns",
 		},
 		{
+			name: "type in rpc parameter",
 			args: args{
 				// cursor is right here           |
 				line:       "rpc MethodName(SearchDashboardReq) returns (SearchDashboardResp) {",
@@ -34,6 +37,7 @@ func Test_getWord(t *testing.T) {
 			want: "SearchDashboardReq",
 		},
 		{
+			name: "cursor on closing parenthesis",
 			args: args{
 				// cursor is right here                        |
 				line:       "rpc MethodName(SearchDashboardReq) returns (SearchDashboardResp) {",
@@ -43,6 +47,7 @@ func Test_getWord(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "qualified name without dot",
 			args: args{
 				// cursor is right here                                           |
 				line:       "rpc MethodName(SearchDashboardReq) returns (google.protobuf.Empty) {",
@@ -52,6 +57,7 @@ func Test_getWord(t *testing.T) {
 			want: "protobuf",
 		},
 		{
+			name: "qualified name with dot",
 			args: args{
 				// cursor is right here                                           |
 				line:       "rpc MethodName(SearchDashboardReq) returns (google.protobuf.Empty) {",
@@ -60,11 +66,165 @@ func Test_getWord(t *testing.T) {
 			},
 			want: "google.protobuf.Empty",
 		},
+		// Additional edge case tests
+		{
+			name: "empty line",
+			args: args{
+				line:       "",
+				idx:        0,
+				includeDot: false,
+			},
+			want: "",
+		},
+		{
+			name: "negative index clamps to 0",
+			args: args{
+				line:       "message Foo",
+				idx:        -5,
+				includeDot: false,
+			},
+			want: "message",
+		},
+		{
+			name: "index past end of line",
+			args: args{
+				line:       "Foo",
+				idx:        100,
+				includeDot: false,
+			},
+			want: "Foo",
+		},
+		{
+			name: "word at start of line",
+			args: args{
+				line:       "message Request {",
+				idx:        0,
+				includeDot: false,
+			},
+			want: "message",
+		},
+		{
+			name: "word at end of line",
+			args: args{
+				line:       "  string name",
+				idx:        12,
+				includeDot: false,
+			},
+			want: "name",
+		},
+		{
+			name: "underscore in identifier",
+			args: args{
+				line:       "  my_field_name = 1;",
+				idx:        5,
+				includeDot: false,
+			},
+			want: "my_field_name",
+		},
+		{
+			name: "cursor on whitespace",
+			args: args{
+				line:       "message   Request",
+				idx:        8,
+				includeDot: false,
+			},
+			want: "",
+		},
+		{
+			name: "single char word",
+			args: args{
+				line:       "a = 1",
+				idx:        0,
+				includeDot: false,
+			},
+			want: "a",
+		},
+		{
+			name: "number in identifier",
+			args: args{
+				line:       "field1 int32 = 1",
+				idx:        3,
+				includeDot: false,
+			},
+			want: "field1",
+		},
 	}
 	for i, tt := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+		name := tt.name
+		if name == "" {
+			name = fmt.Sprint(i)
+		}
+		t.Run(name, func(t *testing.T) {
 			if got := getWord(tt.args.line, tt.args.idx, tt.args.includeDot); got != tt.want {
 				t.Errorf("getWord() = '%v', want '%v'", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_qualifierReferencesPackage(t *testing.T) {
+	tests := []struct {
+		name         string
+		queryPkg     string
+		candidatePkg string
+		currentPkg   string
+		want         bool
+	}{
+		{
+			name:         "fully qualified name matches exactly",
+			queryPkg:     "google.protobuf",
+			candidatePkg: "google.protobuf",
+			currentPkg:   "myapp.service",
+			want:         true,
+		},
+		{
+			name:         "same package prefix allows short reference",
+			queryPkg:     "some.dependency",
+			candidatePkg: "common.some.dependency",
+			currentPkg:   "common.user",
+			want:         true,
+		},
+		{
+			name:         "different package prefix",
+			queryPkg:     "some.dependency",
+			candidatePkg: "other.some.dependency",
+			currentPkg:   "common.user",
+			want:         false,
+		},
+		{
+			name:         "nested package in same hierarchy",
+			queryPkg:     "models",
+			candidatePkg: "myapp.service.models",
+			currentPkg:   "myapp.service",
+			want:         true,
+		},
+		{
+			name:         "current package equals prefix",
+			queryPkg:     "types",
+			candidatePkg: "myapp.types",
+			currentPkg:   "myapp",
+			want:         true,
+		},
+		{
+			name:         "empty query matches nothing",
+			queryPkg:     "",
+			candidatePkg: "some.package",
+			currentPkg:   "other.package",
+			want:         false,
+		},
+		{
+			name:         "same package references itself",
+			queryPkg:     "myapp",
+			candidatePkg: "myapp",
+			currentPkg:   "myapp",
+			want:         true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := qualifierReferencesPackage(tt.queryPkg, tt.candidatePkg, tt.currentPkg); got != tt.want {
+				t.Errorf("qualifierReferencesPackage(%q, %q, %q) = %v, want %v",
+					tt.queryPkg, tt.candidatePkg, tt.currentPkg, got, tt.want)
 			}
 		})
 	}

--- a/components/references.go
+++ b/components/references.go
@@ -1,0 +1,215 @@
+package components
+
+import (
+	"context"
+	"strings"
+
+	"github.com/lasorda/protobuf-language-server/go-lsp/logs"
+	"github.com/lasorda/protobuf-language-server/go-lsp/lsp/defines"
+	"github.com/lasorda/protobuf-language-server/proto/view"
+)
+
+// FindReferences finds all references to the symbol at the given position
+func FindReferences(ctx context.Context, req *defines.ReferenceParams) (result *[]defines.Location, err error) {
+	logs.Printf("FindReferences: uri=%s, line=%d, char=%d", req.TextDocument.Uri, req.Position.Line, req.Position.Character)
+
+	if !view.IsProtoFile(req.TextDocument.Uri) {
+		return nil, nil
+	}
+
+	// Get the proto file
+	protoFile, err := view.ViewManager.GetFile(req.TextDocument.Uri)
+	if err != nil {
+		logs.Printf("FindReferences: GetFile error: %v", err)
+		return nil, err
+	}
+
+	// Extract symbol at cursor position
+	line := protoFile.ReadLine(int(req.Position.Line))
+	if len(line) == 0 {
+		return &[]defines.Location{}, nil
+	}
+
+	// Get the word at cursor (without package prefix for matching)
+	symbolName := getWord(line, int(req.Position.Character), false)
+	if symbolName == "" {
+		logs.Printf("FindReferences: no symbol at position")
+		return &[]defines.Location{}, nil
+	}
+	logs.Printf("FindReferences: looking for symbol '%s'", symbolName)
+
+	// Find the definition to understand what type of symbol we're looking for
+	symbols, _ := findSymbolDefinition(ctx, &req.TextDocumentPositionParams)
+
+	var results []defines.Location
+
+	// Track definition location to avoid duplicates
+	var defUri defines.DocumentUri
+	var defLine uint
+
+	// If we found a definition and includeDeclaration is true, add it
+	if req.Context.IncludeDeclaration && len(symbols) > 0 {
+		for _, sym := range symbols {
+			if sym.Type == DefinitionTypeMessage || sym.Type == DefinitionTypeEnum {
+				var name string
+				if sym.Type == DefinitionTypeMessage {
+					name = sym.Message.Protobuf().Name
+				} else {
+					name = sym.Enum.Protobuf().Name
+				}
+				defUri = defines.DocumentUri(sym.Filename)
+				defLine = sym.Position.Line
+				results = append(results, defines.Location{
+					Uri: defUri,
+					Range: defines.Range{
+						Start: sym.Position,
+						End: defines.Position{
+							Line:      sym.Position.Line,
+							Character: sym.Position.Character + uint(len(name)),
+						},
+					},
+				})
+			}
+		}
+	}
+
+	// Search for references in the current file (skip definition line to avoid duplicates)
+	refs := searchFileForReferences(protoFile, symbolName, defUri, defLine)
+	results = append(results, refs...)
+
+	// Search in imported files (recursively)
+	searchedFiles := make(map[defines.DocumentUri]bool)
+	searchedFiles[protoFile.URI()] = true
+	searchImportedFilesForReferences(protoFile, symbolName, searchedFiles, &results, defUri, defLine)
+
+	logs.Printf("FindReferences: found %d references", len(results))
+	return &results, nil
+}
+
+// searchImportedFilesForReferences recursively searches imported files for references
+func searchImportedFilesForReferences(protoFile view.ProtoFile, symbolName string, searched map[defines.DocumentUri]bool, results *[]defines.Location, defUri defines.DocumentUri, defLine uint) {
+	if protoFile.Proto() == nil {
+		return
+	}
+
+	for _, imp := range protoFile.Proto().Imports() {
+		importUri, err := view.ViewManager.GetDocumentUriFromImportPath(protoFile.URI(), imp.ProtoImport.Filename)
+		if err != nil {
+			continue
+		}
+
+		if searched[importUri] {
+			continue
+		}
+		searched[importUri] = true
+
+		importFile, err := view.ViewManager.GetFile(importUri)
+		if err != nil {
+			continue
+		}
+
+		refs := searchFileForReferences(importFile, symbolName, defUri, defLine)
+		*results = append(*results, refs...)
+
+		// Recursively search this file's imports
+		searchImportedFilesForReferences(importFile, symbolName, searched, results, defUri, defLine)
+	}
+}
+
+// searchFileForReferences searches a single file for all references to the symbol
+// defUri and defLine are used to skip the definition location (to avoid duplicates)
+func searchFileForReferences(protoFile view.ProtoFile, symbolName string, defUri defines.DocumentUri, defLine uint) []defines.Location {
+	var results []defines.Location
+
+	data, _, err := protoFile.Read(context.Background())
+	if err != nil {
+		return results
+	}
+
+	lines := strings.Split(string(data), "\n")
+	fileUri := protoFile.URI()
+
+	for lineNum, line := range lines {
+		// Skip the definition line to avoid duplicates
+		if fileUri == defUri && uint(lineNum) == defLine {
+			continue
+		}
+
+		// Skip empty lines
+		if len(strings.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		// Skip import lines - we don't want to match symbol names in imports
+		if strings.HasPrefix(strings.TrimSpace(line), "import") {
+			continue
+		}
+
+		// Skip comments
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*") {
+			continue
+		}
+
+		// Find all occurrences of the symbol in this line
+		idx := 0
+		for {
+			foundIdx := strings.Index(line[idx:], symbolName)
+			if foundIdx == -1 {
+				break
+			}
+			foundIdx += idx // Adjust to absolute position in line
+
+			// Verify it's a whole word (not part of a larger identifier)
+			if isWholeWord(line, foundIdx, len(symbolName)) {
+				results = append(results, defines.Location{
+					Uri: fileUri,
+					Range: defines.Range{
+						Start: defines.Position{
+							Line:      uint(lineNum),
+							Character: uint(foundIdx),
+						},
+						End: defines.Position{
+							Line:      uint(lineNum),
+							Character: uint(foundIdx + len(symbolName)),
+						},
+					},
+				})
+			}
+
+			idx = foundIdx + 1
+			if idx >= len(line) {
+				break
+			}
+		}
+	}
+
+	return results
+}
+
+// isWholeWord checks if the match at the given position is a complete word
+func isWholeWord(line string, start int, length int) bool {
+	// Check character before
+	if start > 0 {
+		prev := line[start-1]
+		if isIdentifierChar(prev) {
+			return false
+		}
+	}
+
+	// Check character after
+	end := start + length
+	if end < len(line) {
+		next := line[end]
+		if isIdentifierChar(next) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// isIdentifierChar checks if a character can be part of an identifier
+func isIdentifierChar(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_'
+}

--- a/components/references_test.go
+++ b/components/references_test.go
@@ -1,0 +1,391 @@
+package components
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/lasorda/protobuf-language-server/go-lsp/lsp/defines"
+	"github.com/lasorda/protobuf-language-server/proto/parser"
+	"github.com/lasorda/protobuf-language-server/proto/view"
+)
+
+// mockProtoFile implements view.ProtoFile for testing
+type mockProtoFile struct {
+	uri   defines.DocumentUri
+	data  []byte
+	proto parser.Proto
+}
+
+func (m *mockProtoFile) URI() defines.DocumentUri {
+	return m.uri
+}
+
+func (m *mockProtoFile) Read(ctx context.Context) ([]byte, string, error) {
+	return m.data, "", nil
+}
+
+func (m *mockProtoFile) ReadLine(line int) string {
+	lines := splitLines(m.data)
+	if line >= len(lines) {
+		return ""
+	}
+	return lines[line]
+}
+
+func (m *mockProtoFile) Saved() bool {
+	return true
+}
+
+func (m *mockProtoFile) SetSaved(saved bool) {}
+
+func (m *mockProtoFile) Proto() parser.Proto {
+	return m.proto
+}
+
+func (m *mockProtoFile) SetProto(proto parser.Proto) {
+	m.proto = proto
+}
+
+func splitLines(data []byte) []string {
+	if len(data) == 0 {
+		return []string{}
+	}
+	result := []string{}
+	start := 0
+	for i, b := range data {
+		if b == '\n' {
+			result = append(result, string(data[start:i]))
+			start = i + 1
+		}
+	}
+	if start < len(data) {
+		result = append(result, string(data[start:]))
+	}
+	return result
+}
+
+var _ view.ProtoFile = (*mockProtoFile)(nil)
+
+func Test_isIdentifierChar(t *testing.T) {
+	tests := []struct {
+		char byte
+		want bool
+	}{
+		{'a', true},
+		{'z', true},
+		{'A', true},
+		{'Z', true},
+		{'0', true},
+		{'9', true},
+		{'_', true},
+		{'.', false},
+		{' ', false},
+		{'(', false},
+		{')', false},
+		{'{', false},
+		{'}', false},
+		{'=', false},
+		{';', false},
+		{'\t', false},
+		{'\n', false},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("char_%c", tt.char), func(t *testing.T) {
+			if got := isIdentifierChar(tt.char); got != tt.want {
+				t.Errorf("isIdentifierChar(%c) = %v, want %v", tt.char, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isWholeWord(t *testing.T) {
+	tests := []struct {
+		name   string
+		line   string
+		start  int
+		length int
+		want   bool
+	}{
+		{
+			name:   "word at start of line",
+			line:   "Message foo = 1;",
+			start:  0,
+			length: 7,
+			want:   true,
+		},
+		{
+			name:   "word in middle",
+			line:   "  MyMessage request = 1;",
+			start:  2,
+			length: 9,
+			want:   true,
+		},
+		{
+			name:   "word at end of line",
+			line:   "returns (Response)",
+			start:  9,
+			length: 8,
+			want:   true,
+		},
+		{
+			name:   "partial match at start - not whole word",
+			line:   "MyMessageRequest foo = 1;",
+			start:  0,
+			length: 9, // "MyMessage" but line has "MyMessageRequest"
+			want:   false,
+		},
+		{
+			name:   "partial match at end - not whole word",
+			line:   "RequestMessage foo = 1;",
+			start:  7,
+			length: 7, // "Message" but preceded by "Request"
+			want:   false,
+		},
+		{
+			name:   "word after dot (package qualifier)",
+			line:   "google.protobuf.Empty",
+			start:  16,
+			length: 5, // "Empty"
+			want:   true,
+		},
+		{
+			name:   "word before dot",
+			line:   "google.protobuf.Empty",
+			start:  7,
+			length: 8, // "protobuf"
+			want:   true,
+		},
+		{
+			name:   "word in parentheses",
+			line:   "rpc Method(Request) returns (Response)",
+			start:  11,
+			length: 7, // "Request"
+			want:   true,
+		},
+		{
+			name:   "empty line",
+			line:   "",
+			start:  0,
+			length: 0,
+			want:   true,
+		},
+		{
+			name:   "single character word",
+			line:   "a = 1",
+			start:  0,
+			length: 1,
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isWholeWord(tt.line, tt.start, tt.length); got != tt.want {
+				t.Errorf("isWholeWord(%q, %d, %d) = %v, want %v", tt.line, tt.start, tt.length, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_searchFileForReferences(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		symbolName string
+		defUri     defines.DocumentUri
+		defLine    uint
+		wantCount  int
+		wantLines  []uint // expected line numbers
+	}{
+		{
+			name: "finds multiple references",
+			content: `syntax = "proto3";
+message Request {
+  string id = 1;
+}
+message Response {
+  Request request = 1;
+}
+service MyService {
+  rpc Method(Request) returns (Response);
+}`,
+			symbolName: "Request",
+			defUri:     "",
+			defLine:    0,
+			wantCount:  3, // line 1 (definition), line 5 (field type), line 8 (rpc param)
+			wantLines:  []uint{1, 5, 8},
+		},
+		{
+			name: "skips definition line when specified",
+			content: `syntax = "proto3";
+message Request {
+  string id = 1;
+}
+message Response {
+  Request request = 1;
+}`,
+			symbolName: "Request",
+			defUri:     "file:///test.proto",
+			defLine:    1, // skip line 1 (definition)
+			wantCount:  1, // only line 5 (field type)
+			wantLines:  []uint{5},
+		},
+		{
+			name: "skips import lines",
+			content: `syntax = "proto3";
+import "common/request.proto";
+message Response {
+  Request request = 1;
+}`,
+			symbolName: "request",
+			defUri:     "",
+			defLine:    0,
+			wantCount:  1, // only line 3 (field name), import line is skipped
+			wantLines:  []uint{3},
+		},
+		{
+			name: "skips comment lines",
+			content: `syntax = "proto3";
+// Request is a message type
+message Response {
+  Request request = 1;
+}`,
+			symbolName: "Request",
+			defUri:     "",
+			defLine:    0,
+			wantCount:  1, // only line 3, comment is skipped
+			wantLines:  []uint{3},
+		},
+		{
+			name: "does not match partial words",
+			content: `syntax = "proto3";
+message RequestMessage {
+  string id = 1;
+}
+message MyRequest {
+  string id = 1;
+}`,
+			symbolName: "Request",
+			defUri:     "",
+			defLine:    0,
+			wantCount:  0, // "RequestMessage" and "MyRequest" should not match
+			wantLines:  []uint{},
+		},
+		{
+			name: "finds word with package qualifier",
+			content: `syntax = "proto3";
+message Response {
+  google.protobuf.Empty empty = 1;
+}`,
+			symbolName: "Empty",
+			defUri:     "",
+			defLine:    0,
+			wantCount:  1,
+			wantLines:  []uint{2},
+		},
+		{
+			name: "empty file",
+			content:    "",
+			symbolName: "Request",
+			defUri:     "",
+			defLine:    0,
+			wantCount:  0,
+			wantLines:  []uint{},
+		},
+		{
+			name: "finds multiple occurrences on same line",
+			content: `syntax = "proto3";
+message Foo {
+  map<string, Foo> children = 1;
+}`,
+			symbolName: "Foo",
+			defUri:     "",
+			defLine:    0,
+			wantCount:  2, // definition and map value type
+			wantLines:  []uint{1, 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockFile := &mockProtoFile{
+				uri:  "file:///test.proto",
+				data: []byte(tt.content),
+			}
+
+			got := searchFileForReferences(mockFile, tt.symbolName, tt.defUri, tt.defLine)
+
+			if len(got) != tt.wantCount {
+				t.Errorf("searchFileForReferences() returned %d results, want %d", len(got), tt.wantCount)
+				for i, loc := range got {
+					t.Logf("  result[%d]: line %d, char %d", i, loc.Range.Start.Line, loc.Range.Start.Character)
+				}
+				return
+			}
+
+			// Verify line numbers
+			for i, wantLine := range tt.wantLines {
+				if i >= len(got) {
+					break
+				}
+				if got[i].Range.Start.Line != wantLine {
+					t.Errorf("result[%d] line = %d, want %d", i, got[i].Range.Start.Line, wantLine)
+				}
+			}
+		})
+	}
+}
+
+func Test_searchFileForReferences_characterPositions(t *testing.T) {
+	content := `message Request {
+  string name = 1;
+}
+message Response {
+  Request data = 1;
+}`
+	mockFile := &mockProtoFile{
+		uri:  "file:///test.proto",
+		data: []byte(content),
+	}
+
+	results := searchFileForReferences(mockFile, "Request", "", 0)
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	// First occurrence: "message Request {" - Request starts at character 8
+	if results[0].Range.Start.Character != 8 {
+		t.Errorf("first result start character = %d, want 8", results[0].Range.Start.Character)
+	}
+	if results[0].Range.End.Character != 15 { // 8 + len("Request")
+		t.Errorf("first result end character = %d, want 15", results[0].Range.End.Character)
+	}
+
+	// Second occurrence: "  Request data = 1;" - Request starts at character 2
+	if results[1].Range.Start.Character != 2 {
+		t.Errorf("second result start character = %d, want 2", results[1].Range.Start.Character)
+	}
+	if results[1].Range.End.Character != 9 { // 2 + len("Request")
+		t.Errorf("second result end character = %d, want 9", results[1].Range.End.Character)
+	}
+}
+
+func Test_searchFileForReferences_uri(t *testing.T) {
+	content := `message Foo {}`
+	uri := defines.DocumentUri("file:///path/to/my.proto")
+	mockFile := &mockProtoFile{
+		uri:  uri,
+		data: []byte(content),
+	}
+
+	results := searchFileForReferences(mockFile, "Foo", "", 0)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if results[0].Uri != uri {
+		t.Errorf("result URI = %q, want %q", results[0].Uri, uri)
+	}
+}

--- a/go-lsp/lsp/methods_gen.go
+++ b/go-lsp/lsp/methods_gen.go
@@ -9,53 +9,55 @@ import (
 )
 
 type Methods struct {
-	Opt                                        Options
-	onInitialize                               func(ctx context.Context, req *defines.InitializeParams) (*defines.InitializeResult, *defines.InitializeError)
-	onInitialized                              func(ctx context.Context, req *defines.InitializeParams) error
-	onShutdown                                 func(ctx context.Context, req *interface{}) error
-	onExit                                     func(ctx context.Context, req *interface{}) error
-	onDidChangeConfiguration                   func(ctx context.Context, req *defines.DidChangeConfigurationParams) error
-	onDidChangeWatchedFiles                    func(ctx context.Context, req *defines.DidChangeWatchedFilesParams) error
-	onDidOpenTextDocument                      func(ctx context.Context, req *defines.DidOpenTextDocumentParams) error
-	onDidChangeTextDocument                    func(ctx context.Context, req *defines.DidChangeTextDocumentParams) error
-	onDidCloseTextDocument                     func(ctx context.Context, req *defines.DidCloseTextDocumentParams) error
-	onWillSaveTextDocument                     func(ctx context.Context, req *defines.WillSaveTextDocumentParams) error
-	onDidSaveTextDocument                      func(ctx context.Context, req *defines.DidSaveTextDocumentParams) error
-	onExecuteCommand                           func(ctx context.Context, req *defines.ExecuteCommandParams) error
-	onHover                                    func(ctx context.Context, req *defines.HoverParams) (*defines.Hover, error)
-	onCompletion                               func(ctx context.Context, req *defines.CompletionParams) (*[]defines.CompletionItem, error)
-	onCompletionResolve                        func(ctx context.Context, req *defines.CompletionItem) (*defines.CompletionItem, error)
-	onSignatureHelp                            func(ctx context.Context, req *defines.SignatureHelpParams) (*defines.SignatureHelp, error)
-	onDeclaration                              func(ctx context.Context, req *defines.DeclarationParams) (*[]defines.LocationLink, error)
-	onDefinition                               func(ctx context.Context, req *defines.DefinitionParams) (*[]defines.LocationLink, error)
-	onTypeDefinition                           func(ctx context.Context, req *defines.TypeDefinitionParams) (*[]defines.LocationLink, error)
-	onImplementation                           func(ctx context.Context, req *defines.ImplementationParams) (*[]defines.LocationLink, error)
-	onReferences                               func(ctx context.Context, req *defines.ReferenceParams) (*[]defines.Location, error)
-	onDocumentHighlight                        func(ctx context.Context, req *defines.DocumentHighlightParams) (*[]defines.DocumentHighlight, error)
-	onDocumentSymbolWithSliceDocumentSymbol    func(ctx context.Context, req *defines.DocumentSymbolParams) (*[]defines.DocumentSymbol, error)
+    Opt Options
+	onInitialize func(ctx context.Context, req *defines.InitializeParams) (*defines.InitializeResult, *defines.InitializeError)
+	onInitialized func(ctx context.Context, req *defines.InitializeParams) error
+	onShutdown func(ctx context.Context, req *interface{}) error
+	onExit func(ctx context.Context, req *interface{}) error
+	onDidChangeConfiguration func(ctx context.Context, req *defines.DidChangeConfigurationParams) error
+	onDidChangeWatchedFiles func(ctx context.Context, req *defines.DidChangeWatchedFilesParams) error
+	onDidOpenTextDocument func(ctx context.Context, req *defines.DidOpenTextDocumentParams) error
+	onDidChangeTextDocument func(ctx context.Context, req *defines.DidChangeTextDocumentParams) error
+	onDidCloseTextDocument func(ctx context.Context, req *defines.DidCloseTextDocumentParams) error
+	onWillSaveTextDocument func(ctx context.Context, req *defines.WillSaveTextDocumentParams) error
+	onDidSaveTextDocument func(ctx context.Context, req *defines.DidSaveTextDocumentParams) error
+	onExecuteCommand func(ctx context.Context, req *defines.ExecuteCommandParams) error
+	onHover func(ctx context.Context, req *defines.HoverParams) (*defines.Hover, error)
+	onCompletion func(ctx context.Context, req *defines.CompletionParams) (*[]defines.CompletionItem, error)
+	onCompletionResolve func(ctx context.Context, req *defines.CompletionItem) (*defines.CompletionItem, error)
+	onSignatureHelp func(ctx context.Context, req *defines.SignatureHelpParams) (*defines.SignatureHelp, error)
+	onDeclaration func(ctx context.Context, req *defines.DeclarationParams) (*[]defines.LocationLink, error)
+	onDefinition func(ctx context.Context, req *defines.DefinitionParams) (*[]defines.LocationLink, error)
+	onTypeDefinition func(ctx context.Context, req *defines.TypeDefinitionParams) (*[]defines.LocationLink, error)
+	onImplementation func(ctx context.Context, req *defines.ImplementationParams) (*[]defines.LocationLink, error)
+	onReferences func(ctx context.Context, req *defines.ReferenceParams) (*[]defines.Location, error)
+	onDocumentHighlight func(ctx context.Context, req *defines.DocumentHighlightParams) (*[]defines.DocumentHighlight, error)
+	onDocumentSymbolWithSliceDocumentSymbol func(ctx context.Context, req *defines.DocumentSymbolParams) (*[]defines.DocumentSymbol, error)
 	onDocumentSymbolWithSliceSymbolInformation func(ctx context.Context, req *defines.DocumentSymbolParams) (*[]defines.SymbolInformation, error)
-	onWorkspaceSymbol                          func(ctx context.Context, req *defines.WorkspaceSymbolParams) (*[]defines.SymbolInformation, error)
-	onCodeActionWithSliceCommand               func(ctx context.Context, req *defines.CodeActionParams) (*[]defines.Command, error)
-	onCodeActionWithSliceCodeAction            func(ctx context.Context, req *defines.CodeActionParams) (*[]defines.CodeAction, error)
-	onCodeActionResolve                        func(ctx context.Context, req *defines.CodeAction) (*defines.CodeAction, error)
-	onCodeLens                                 func(ctx context.Context, req *defines.CodeLensParams) (*[]defines.CodeLens, error)
-	onCodeLensResolve                          func(ctx context.Context, req *defines.CodeLens) (*defines.CodeLens, error)
-	onDocumentFormatting                       func(ctx context.Context, req *defines.DocumentFormattingParams) (*[]defines.TextEdit, error)
-	onDocumentRangeFormatting                  func(ctx context.Context, req *defines.DocumentRangeFormattingParams) (*[]defines.TextEdit, error)
-	onDocumentOnTypeFormatting                 func(ctx context.Context, req *defines.DocumentOnTypeFormattingParams) (*[]defines.TextEdit, error)
-	onRenameRequest                            func(ctx context.Context, req *defines.RenameParams) (*defines.WorkspaceEdit, error)
-	onPrepareRename                            func(ctx context.Context, req *defines.PrepareRenameParams) (*defines.Range, error)
-	onDocumentLinks                            func(ctx context.Context, req *defines.DocumentLinkParams) (*[]defines.DocumentLink, error)
-	onDocumentLinkResolve                      func(ctx context.Context, req *defines.DocumentLink) (*defines.DocumentLink, error)
-	onDocumentColor                            func(ctx context.Context, req *defines.DocumentColorParams) (*[]defines.ColorInformation, error)
-	onColorPresentation                        func(ctx context.Context, req *defines.ColorPresentationParams) (*[]defines.ColorPresentation, error)
-	onFoldingRanges                            func(ctx context.Context, req *defines.FoldingRangeParams) (*[]defines.FoldingRange, error)
-	onSelectionRanges                          func(ctx context.Context, req *defines.SelectionRangeParams) (*[]defines.SelectionRange, error)
+	onWorkspaceSymbol func(ctx context.Context, req *defines.WorkspaceSymbolParams) (*[]defines.SymbolInformation, error)
+	onCodeActionWithSliceCommand func(ctx context.Context, req *defines.CodeActionParams) (*[]defines.Command, error)
+	onCodeActionWithSliceCodeAction func(ctx context.Context, req *defines.CodeActionParams) (*[]defines.CodeAction, error)
+	onCodeActionResolve func(ctx context.Context, req *defines.CodeAction) (*defines.CodeAction, error)
+	onCodeLens func(ctx context.Context, req *defines.CodeLensParams) (*[]defines.CodeLens, error)
+	onCodeLensResolve func(ctx context.Context, req *defines.CodeLens) (*defines.CodeLens, error)
+	onDocumentFormatting func(ctx context.Context, req *defines.DocumentFormattingParams) (*[]defines.TextEdit, error)
+	onDocumentRangeFormatting func(ctx context.Context, req *defines.DocumentRangeFormattingParams) (*[]defines.TextEdit, error)
+	onDocumentOnTypeFormatting func(ctx context.Context, req *defines.DocumentOnTypeFormattingParams) (*[]defines.TextEdit, error)
+	onRenameRequest func(ctx context.Context, req *defines.RenameParams) (*defines.WorkspaceEdit, error)
+	onPrepareRename func(ctx context.Context, req *defines.PrepareRenameParams) (*defines.Range, error)
+	onDocumentLinks func(ctx context.Context, req *defines.DocumentLinkParams) (*[]defines.DocumentLink, error)
+	onDocumentLinkResolve func(ctx context.Context, req *defines.DocumentLink) (*defines.DocumentLink, error)
+	onDocumentColor func(ctx context.Context, req *defines.DocumentColorParams) (*[]defines.ColorInformation, error)
+	onColorPresentation func(ctx context.Context, req *defines.ColorPresentationParams) (*[]defines.ColorPresentation, error)
+	onFoldingRanges func(ctx context.Context, req *defines.FoldingRangeParams) (*[]defines.FoldingRange, error)
+	onSelectionRanges func(ctx context.Context, req *defines.SelectionRangeParams) (*[]defines.SelectionRange, error)
 }
+
 
 func (m *Methods) OnInitialize(f func(ctx context.Context, req *defines.InitializeParams) (result *defines.InitializeResult, err *defines.InitializeError)) {
 	m.onInitialize = f
 }
+
 
 func (m *Methods) initialize(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.InitializeParams)
@@ -71,9 +73,10 @@ func (m *Methods) initialize(ctx context.Context, req interface{}) (interface{},
 
 }
 
-func (m *Methods) initializeMethodInfo() *jsonrpc.MethodInfo {
 
-	return &jsonrpc.MethodInfo{
+func (m *Methods) initializeMethodInfo() *jsonrpc.MethodInfo {
+	
+    return &jsonrpc.MethodInfo{
 		Name: "initialize",
 		NewRequest: func() interface{} {
 			return &defines.InitializeParams{}
@@ -82,9 +85,11 @@ func (m *Methods) initializeMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnInitialized(f func(ctx context.Context, req *defines.InitializeParams) (err error)) {
 	m.onInitialized = f
 }
+
 
 func (m *Methods) initialized(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.InitializeParams)
@@ -93,15 +98,16 @@ func (m *Methods) initialized(ctx context.Context, req interface{}) (interface{}
 		e := wrapErrorToRespError(err, 0)
 		return nil, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) initializedMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onInitialized == nil {
+    if m.onInitialized == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "initialized",
 		NewRequest: func() interface{} {
 			return &defines.InitializeParams{}
@@ -110,9 +116,11 @@ func (m *Methods) initializedMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnShutdown(f func(ctx context.Context, req *interface{}) (err error)) {
 	m.onShutdown = f
 }
+
 
 func (m *Methods) shutdown(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*interface{})
@@ -121,15 +129,16 @@ func (m *Methods) shutdown(ctx context.Context, req interface{}) (interface{}, e
 		e := wrapErrorToRespError(err, 0)
 		return nil, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) shutdownMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onShutdown == nil {
+    if m.onShutdown == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "shutdown",
 		NewRequest: func() interface{} {
 			return nil
@@ -138,9 +147,11 @@ func (m *Methods) shutdownMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnExit(f func(ctx context.Context, req *interface{}) (err error)) {
 	m.onExit = f
 }
+
 
 func (m *Methods) exit(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*interface{})
@@ -149,15 +160,16 @@ func (m *Methods) exit(ctx context.Context, req interface{}) (interface{}, error
 		e := wrapErrorToRespError(err, 0)
 		return nil, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) exitMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onExit == nil {
+    if m.onExit == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "exit",
 		NewRequest: func() interface{} {
 			return nil
@@ -166,9 +178,11 @@ func (m *Methods) exitMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDidChangeConfiguration(f func(ctx context.Context, req *defines.DidChangeConfigurationParams) (err error)) {
 	m.onDidChangeConfiguration = f
 }
+
 
 func (m *Methods) didChangeConfiguration(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DidChangeConfigurationParams)
@@ -177,16 +191,17 @@ func (m *Methods) didChangeConfiguration(ctx context.Context, req interface{}) (
 		e := wrapErrorToRespError(err, 0)
 		return nil, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) didChangeConfigurationMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDidChangeConfiguration == nil {
+    if m.onDidChangeConfiguration == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
-		Name: "workspace/didChangeConfiguration",
+	}	
+    return &jsonrpc.MethodInfo{
+		Name: "didChangeConfiguration",
 		NewRequest: func() interface{} {
 			return &defines.DidChangeConfigurationParams{}
 		},
@@ -194,9 +209,11 @@ func (m *Methods) didChangeConfigurationMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDidChangeWatchedFiles(f func(ctx context.Context, req *defines.DidChangeWatchedFilesParams) (err error)) {
 	m.onDidChangeWatchedFiles = f
 }
+
 
 func (m *Methods) didChangeWatchedFiles(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DidChangeWatchedFilesParams)
@@ -205,15 +222,16 @@ func (m *Methods) didChangeWatchedFiles(ctx context.Context, req interface{}) (i
 		e := wrapErrorToRespError(err, 0)
 		return nil, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) didChangeWatchedFilesMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDidChangeWatchedFiles == nil {
+    if m.onDidChangeWatchedFiles == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "didChangeWatchedFiles",
 		NewRequest: func() interface{} {
 			return &defines.DidChangeWatchedFilesParams{}
@@ -222,9 +240,11 @@ func (m *Methods) didChangeWatchedFilesMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDidOpenTextDocument(f func(ctx context.Context, req *defines.DidOpenTextDocumentParams) (err error)) {
 	m.onDidOpenTextDocument = f
 }
+
 
 func (m *Methods) didOpenTextDocument(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DidOpenTextDocumentParams)
@@ -233,16 +253,17 @@ func (m *Methods) didOpenTextDocument(ctx context.Context, req interface{}) (int
 		e := wrapErrorToRespError(err, 0)
 		return nil, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) didOpenTextDocumentMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDidOpenTextDocument == nil {
+    if m.onDidOpenTextDocument == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
-		Name: "textDocument/didOpen",
+	}	
+    return &jsonrpc.MethodInfo{
+		Name: "didOpenTextDocument",
 		NewRequest: func() interface{} {
 			return &defines.DidOpenTextDocumentParams{}
 		},
@@ -250,9 +271,11 @@ func (m *Methods) didOpenTextDocumentMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDidChangeTextDocument(f func(ctx context.Context, req *defines.DidChangeTextDocumentParams) (err error)) {
 	m.onDidChangeTextDocument = f
 }
+
 
 func (m *Methods) didChangeTextDocument(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DidChangeTextDocumentParams)
@@ -261,16 +284,17 @@ func (m *Methods) didChangeTextDocument(ctx context.Context, req interface{}) (i
 		e := wrapErrorToRespError(err, 0)
 		return nil, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) didChangeTextDocumentMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDidChangeTextDocument == nil {
+    if m.onDidChangeTextDocument == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
-		Name: "textDocument/didChange",
+	}	
+    return &jsonrpc.MethodInfo{
+		Name: "didChangeTextDocument",
 		NewRequest: func() interface{} {
 			return &defines.DidChangeTextDocumentParams{}
 		},
@@ -278,9 +302,11 @@ func (m *Methods) didChangeTextDocumentMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDidCloseTextDocument(f func(ctx context.Context, req *defines.DidCloseTextDocumentParams) (err error)) {
 	m.onDidCloseTextDocument = f
 }
+
 
 func (m *Methods) didCloseTextDocument(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DidCloseTextDocumentParams)
@@ -289,16 +315,17 @@ func (m *Methods) didCloseTextDocument(ctx context.Context, req interface{}) (in
 		e := wrapErrorToRespError(err, 0)
 		return nil, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) didCloseTextDocumentMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDidCloseTextDocument == nil {
+    if m.onDidCloseTextDocument == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
-		Name: "textDocument/didClose",
+	}	
+    return &jsonrpc.MethodInfo{
+		Name: "didCloseTextDocument",
 		NewRequest: func() interface{} {
 			return &defines.DidCloseTextDocumentParams{}
 		},
@@ -306,9 +333,11 @@ func (m *Methods) didCloseTextDocumentMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnWillSaveTextDocument(f func(ctx context.Context, req *defines.WillSaveTextDocumentParams) (err error)) {
 	m.onWillSaveTextDocument = f
 }
+
 
 func (m *Methods) willSaveTextDocument(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.WillSaveTextDocumentParams)
@@ -317,15 +346,16 @@ func (m *Methods) willSaveTextDocument(ctx context.Context, req interface{}) (in
 		e := wrapErrorToRespError(err, 0)
 		return nil, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) willSaveTextDocumentMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onWillSaveTextDocument == nil {
+    if m.onWillSaveTextDocument == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "willSaveTextDocument",
 		NewRequest: func() interface{} {
 			return &defines.WillSaveTextDocumentParams{}
@@ -334,9 +364,11 @@ func (m *Methods) willSaveTextDocumentMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDidSaveTextDocument(f func(ctx context.Context, req *defines.DidSaveTextDocumentParams) (err error)) {
 	m.onDidSaveTextDocument = f
 }
+
 
 func (m *Methods) didSaveTextDocument(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DidSaveTextDocumentParams)
@@ -345,16 +377,17 @@ func (m *Methods) didSaveTextDocument(ctx context.Context, req interface{}) (int
 		e := wrapErrorToRespError(err, 0)
 		return nil, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) didSaveTextDocumentMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDidSaveTextDocument == nil {
+    if m.onDidSaveTextDocument == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
-		Name: "textDocument/didSave",
+	}	
+    return &jsonrpc.MethodInfo{
+		Name: "didSaveTextDocument",
 		NewRequest: func() interface{} {
 			return &defines.DidSaveTextDocumentParams{}
 		},
@@ -362,9 +395,11 @@ func (m *Methods) didSaveTextDocumentMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnExecuteCommand(f func(ctx context.Context, req *defines.ExecuteCommandParams) (err error)) {
 	m.onExecuteCommand = f
 }
+
 
 func (m *Methods) executeCommand(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.ExecuteCommandParams)
@@ -373,15 +408,16 @@ func (m *Methods) executeCommand(ctx context.Context, req interface{}) (interfac
 		e := wrapErrorToRespError(err, 0)
 		return nil, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) executeCommandMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onExecuteCommand == nil {
+    if m.onExecuteCommand == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "executeCommand",
 		NewRequest: func() interface{} {
 			return &defines.ExecuteCommandParams{}
@@ -390,9 +426,11 @@ func (m *Methods) executeCommandMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnHover(f func(ctx context.Context, req *defines.HoverParams) (result *defines.Hover, err error)) {
 	m.onHover = f
 }
+
 
 func (m *Methods) hover(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.HoverParams)
@@ -401,15 +439,16 @@ func (m *Methods) hover(ctx context.Context, req interface{}) (interface{}, erro
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) hoverMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onHover == nil {
+    if m.onHover == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/hover",
 		NewRequest: func() interface{} {
 			return &defines.HoverParams{}
@@ -418,9 +457,11 @@ func (m *Methods) hoverMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnCompletion(f func(ctx context.Context, req *defines.CompletionParams) (result *[]defines.CompletionItem, err error)) {
 	m.onCompletion = f
 }
+
 
 func (m *Methods) completion(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.CompletionParams)
@@ -429,15 +470,16 @@ func (m *Methods) completion(ctx context.Context, req interface{}) (interface{},
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) completionMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onCompletion == nil {
+    if m.onCompletion == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/completion",
 		NewRequest: func() interface{} {
 			return &defines.CompletionParams{}
@@ -446,9 +488,11 @@ func (m *Methods) completionMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnCompletionResolve(f func(ctx context.Context, req *defines.CompletionItem) (result *defines.CompletionItem, err error)) {
 	m.onCompletionResolve = f
 }
+
 
 func (m *Methods) completionResolve(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.CompletionItem)
@@ -457,15 +501,16 @@ func (m *Methods) completionResolve(ctx context.Context, req interface{}) (inter
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) completionResolveMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onCompletionResolve == nil {
+    if m.onCompletionResolve == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "completionItem/resolve",
 		NewRequest: func() interface{} {
 			return &defines.CompletionItem{}
@@ -474,9 +519,11 @@ func (m *Methods) completionResolveMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnSignatureHelp(f func(ctx context.Context, req *defines.SignatureHelpParams) (result *defines.SignatureHelp, err error)) {
 	m.onSignatureHelp = f
 }
+
 
 func (m *Methods) signatureHelp(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.SignatureHelpParams)
@@ -485,15 +532,16 @@ func (m *Methods) signatureHelp(ctx context.Context, req interface{}) (interface
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) signatureHelpMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onSignatureHelp == nil {
+    if m.onSignatureHelp == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/signatureHelp",
 		NewRequest: func() interface{} {
 			return &defines.SignatureHelpParams{}
@@ -502,9 +550,11 @@ func (m *Methods) signatureHelpMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDeclaration(f func(ctx context.Context, req *defines.DeclarationParams) (result *[]defines.LocationLink, err error)) {
 	m.onDeclaration = f
 }
+
 
 func (m *Methods) declaration(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DeclarationParams)
@@ -513,15 +563,16 @@ func (m *Methods) declaration(ctx context.Context, req interface{}) (interface{}
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) declarationMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDeclaration == nil {
+    if m.onDeclaration == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/declaration",
 		NewRequest: func() interface{} {
 			return &defines.DeclarationParams{}
@@ -530,9 +581,11 @@ func (m *Methods) declarationMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDefinition(f func(ctx context.Context, req *defines.DefinitionParams) (result *[]defines.LocationLink, err error)) {
 	m.onDefinition = f
 }
+
 
 func (m *Methods) definition(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DefinitionParams)
@@ -541,15 +594,16 @@ func (m *Methods) definition(ctx context.Context, req interface{}) (interface{},
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) definitionMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDefinition == nil {
+    if m.onDefinition == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/definition",
 		NewRequest: func() interface{} {
 			return &defines.DefinitionParams{}
@@ -558,9 +612,11 @@ func (m *Methods) definitionMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnTypeDefinition(f func(ctx context.Context, req *defines.TypeDefinitionParams) (result *[]defines.LocationLink, err error)) {
 	m.onTypeDefinition = f
 }
+
 
 func (m *Methods) typeDefinition(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.TypeDefinitionParams)
@@ -569,15 +625,16 @@ func (m *Methods) typeDefinition(ctx context.Context, req interface{}) (interfac
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) typeDefinitionMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onTypeDefinition == nil {
+    if m.onTypeDefinition == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/typeDefinition",
 		NewRequest: func() interface{} {
 			return &defines.TypeDefinitionParams{}
@@ -586,9 +643,11 @@ func (m *Methods) typeDefinitionMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnImplementation(f func(ctx context.Context, req *defines.ImplementationParams) (result *[]defines.LocationLink, err error)) {
 	m.onImplementation = f
 }
+
 
 func (m *Methods) implementation(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.ImplementationParams)
@@ -597,15 +656,16 @@ func (m *Methods) implementation(ctx context.Context, req interface{}) (interfac
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) implementationMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onImplementation == nil {
+    if m.onImplementation == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/implementation",
 		NewRequest: func() interface{} {
 			return &defines.ImplementationParams{}
@@ -614,9 +674,11 @@ func (m *Methods) implementationMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnReferences(f func(ctx context.Context, req *defines.ReferenceParams) (result *[]defines.Location, err error)) {
 	m.onReferences = f
 }
+
 
 func (m *Methods) references(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.ReferenceParams)
@@ -625,15 +687,16 @@ func (m *Methods) references(ctx context.Context, req interface{}) (interface{},
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) referencesMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onReferences == nil {
+    if m.onReferences == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/references",
 		NewRequest: func() interface{} {
 			return &defines.ReferenceParams{}
@@ -642,9 +705,11 @@ func (m *Methods) referencesMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDocumentHighlight(f func(ctx context.Context, req *defines.DocumentHighlightParams) (result *[]defines.DocumentHighlight, err error)) {
 	m.onDocumentHighlight = f
 }
+
 
 func (m *Methods) documentHighlight(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DocumentHighlightParams)
@@ -653,15 +718,16 @@ func (m *Methods) documentHighlight(ctx context.Context, req interface{}) (inter
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) documentHighlightMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDocumentHighlight == nil {
+    if m.onDocumentHighlight == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/documentHighlight",
 		NewRequest: func() interface{} {
 			return &defines.DocumentHighlightParams{}
@@ -670,9 +736,11 @@ func (m *Methods) documentHighlightMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDocumentSymbolWithSliceDocumentSymbol(f func(ctx context.Context, req *defines.DocumentSymbolParams) (result *[]defines.DocumentSymbol, err error)) {
 	m.onDocumentSymbolWithSliceDocumentSymbol = f
 }
+
 
 func (m *Methods) documentSymbolWithSliceDocumentSymbol(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DocumentSymbolParams)
@@ -681,15 +749,16 @@ func (m *Methods) documentSymbolWithSliceDocumentSymbol(ctx context.Context, req
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) documentSymbolWithSliceDocumentSymbolMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDocumentSymbolWithSliceDocumentSymbol == nil {
+    if m.onDocumentSymbolWithSliceDocumentSymbol == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/documentSymbol",
 		NewRequest: func() interface{} {
 			return &defines.DocumentSymbolParams{}
@@ -698,9 +767,11 @@ func (m *Methods) documentSymbolWithSliceDocumentSymbolMethodInfo() *jsonrpc.Met
 	}
 }
 
+
 func (m *Methods) OnDocumentSymbolWithSliceSymbolInformation(f func(ctx context.Context, req *defines.DocumentSymbolParams) (result *[]defines.SymbolInformation, err error)) {
 	m.onDocumentSymbolWithSliceSymbolInformation = f
 }
+
 
 func (m *Methods) documentSymbolWithSliceSymbolInformation(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DocumentSymbolParams)
@@ -709,15 +780,16 @@ func (m *Methods) documentSymbolWithSliceSymbolInformation(ctx context.Context, 
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) documentSymbolWithSliceSymbolInformationMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDocumentSymbolWithSliceSymbolInformation == nil {
+    if m.onDocumentSymbolWithSliceSymbolInformation == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/documentSymbol",
 		NewRequest: func() interface{} {
 			return &defines.DocumentSymbolParams{}
@@ -726,9 +798,11 @@ func (m *Methods) documentSymbolWithSliceSymbolInformationMethodInfo() *jsonrpc.
 	}
 }
 
+
 func (m *Methods) OnWorkspaceSymbol(f func(ctx context.Context, req *defines.WorkspaceSymbolParams) (result *[]defines.SymbolInformation, err error)) {
 	m.onWorkspaceSymbol = f
 }
+
 
 func (m *Methods) workspaceSymbol(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.WorkspaceSymbolParams)
@@ -737,15 +811,16 @@ func (m *Methods) workspaceSymbol(ctx context.Context, req interface{}) (interfa
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) workspaceSymbolMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onWorkspaceSymbol == nil {
+    if m.onWorkspaceSymbol == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "workspace/symbol",
 		NewRequest: func() interface{} {
 			return &defines.WorkspaceSymbolParams{}
@@ -754,9 +829,11 @@ func (m *Methods) workspaceSymbolMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnCodeActionWithSliceCommand(f func(ctx context.Context, req *defines.CodeActionParams) (result *[]defines.Command, err error)) {
 	m.onCodeActionWithSliceCommand = f
 }
+
 
 func (m *Methods) codeActionWithSliceCommand(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.CodeActionParams)
@@ -765,15 +842,16 @@ func (m *Methods) codeActionWithSliceCommand(ctx context.Context, req interface{
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) codeActionWithSliceCommandMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onCodeActionWithSliceCommand == nil {
+    if m.onCodeActionWithSliceCommand == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/codeAction",
 		NewRequest: func() interface{} {
 			return &defines.CodeActionParams{}
@@ -782,9 +860,11 @@ func (m *Methods) codeActionWithSliceCommandMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnCodeActionWithSliceCodeAction(f func(ctx context.Context, req *defines.CodeActionParams) (result *[]defines.CodeAction, err error)) {
 	m.onCodeActionWithSliceCodeAction = f
 }
+
 
 func (m *Methods) codeActionWithSliceCodeAction(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.CodeActionParams)
@@ -793,15 +873,16 @@ func (m *Methods) codeActionWithSliceCodeAction(ctx context.Context, req interfa
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) codeActionWithSliceCodeActionMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onCodeActionWithSliceCodeAction == nil {
+    if m.onCodeActionWithSliceCodeAction == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/codeAction",
 		NewRequest: func() interface{} {
 			return &defines.CodeActionParams{}
@@ -810,9 +891,11 @@ func (m *Methods) codeActionWithSliceCodeActionMethodInfo() *jsonrpc.MethodInfo 
 	}
 }
 
+
 func (m *Methods) OnCodeActionResolve(f func(ctx context.Context, req *defines.CodeAction) (result *defines.CodeAction, err error)) {
 	m.onCodeActionResolve = f
 }
+
 
 func (m *Methods) codeActionResolve(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.CodeAction)
@@ -821,15 +904,16 @@ func (m *Methods) codeActionResolve(ctx context.Context, req interface{}) (inter
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) codeActionResolveMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onCodeActionResolve == nil {
+    if m.onCodeActionResolve == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "codeAction/resolve",
 		NewRequest: func() interface{} {
 			return &defines.CodeAction{}
@@ -838,9 +922,11 @@ func (m *Methods) codeActionResolveMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnCodeLens(f func(ctx context.Context, req *defines.CodeLensParams) (result *[]defines.CodeLens, err error)) {
 	m.onCodeLens = f
 }
+
 
 func (m *Methods) codeLens(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.CodeLensParams)
@@ -849,15 +935,16 @@ func (m *Methods) codeLens(ctx context.Context, req interface{}) (interface{}, e
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) codeLensMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onCodeLens == nil {
+    if m.onCodeLens == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/codeLens",
 		NewRequest: func() interface{} {
 			return &defines.CodeLensParams{}
@@ -866,9 +953,11 @@ func (m *Methods) codeLensMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnCodeLensResolve(f func(ctx context.Context, req *defines.CodeLens) (result *defines.CodeLens, err error)) {
 	m.onCodeLensResolve = f
 }
+
 
 func (m *Methods) codeLensResolve(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.CodeLens)
@@ -877,15 +966,16 @@ func (m *Methods) codeLensResolve(ctx context.Context, req interface{}) (interfa
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) codeLensResolveMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onCodeLensResolve == nil {
+    if m.onCodeLensResolve == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "codeLens/resolve",
 		NewRequest: func() interface{} {
 			return &defines.CodeLens{}
@@ -894,9 +984,11 @@ func (m *Methods) codeLensResolveMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDocumentFormatting(f func(ctx context.Context, req *defines.DocumentFormattingParams) (result *[]defines.TextEdit, err error)) {
 	m.onDocumentFormatting = f
 }
+
 
 func (m *Methods) documentFormatting(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DocumentFormattingParams)
@@ -905,15 +997,16 @@ func (m *Methods) documentFormatting(ctx context.Context, req interface{}) (inte
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) documentFormattingMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDocumentFormatting == nil {
+    if m.onDocumentFormatting == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/formatting",
 		NewRequest: func() interface{} {
 			return &defines.DocumentFormattingParams{}
@@ -922,9 +1015,11 @@ func (m *Methods) documentFormattingMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDocumentRangeFormatting(f func(ctx context.Context, req *defines.DocumentRangeFormattingParams) (result *[]defines.TextEdit, err error)) {
 	m.onDocumentRangeFormatting = f
 }
+
 
 func (m *Methods) documentRangeFormatting(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DocumentRangeFormattingParams)
@@ -933,15 +1028,16 @@ func (m *Methods) documentRangeFormatting(ctx context.Context, req interface{}) 
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) documentRangeFormattingMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDocumentRangeFormatting == nil {
+    if m.onDocumentRangeFormatting == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/rangeFormatting",
 		NewRequest: func() interface{} {
 			return &defines.DocumentRangeFormattingParams{}
@@ -950,9 +1046,11 @@ func (m *Methods) documentRangeFormattingMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDocumentOnTypeFormatting(f func(ctx context.Context, req *defines.DocumentOnTypeFormattingParams) (result *[]defines.TextEdit, err error)) {
 	m.onDocumentOnTypeFormatting = f
 }
+
 
 func (m *Methods) documentOnTypeFormatting(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DocumentOnTypeFormattingParams)
@@ -961,15 +1059,16 @@ func (m *Methods) documentOnTypeFormatting(ctx context.Context, req interface{})
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) documentOnTypeFormattingMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDocumentOnTypeFormatting == nil {
+    if m.onDocumentOnTypeFormatting == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/onTypeFormatting",
 		NewRequest: func() interface{} {
 			return &defines.DocumentOnTypeFormattingParams{}
@@ -978,9 +1077,11 @@ func (m *Methods) documentOnTypeFormattingMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnRenameRequest(f func(ctx context.Context, req *defines.RenameParams) (result *defines.WorkspaceEdit, err error)) {
 	m.onRenameRequest = f
 }
+
 
 func (m *Methods) renameRequest(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.RenameParams)
@@ -989,15 +1090,16 @@ func (m *Methods) renameRequest(ctx context.Context, req interface{}) (interface
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) renameRequestMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onRenameRequest == nil {
+    if m.onRenameRequest == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/rename",
 		NewRequest: func() interface{} {
 			return &defines.RenameParams{}
@@ -1006,9 +1108,11 @@ func (m *Methods) renameRequestMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnPrepareRename(f func(ctx context.Context, req *defines.PrepareRenameParams) (result *defines.Range, err error)) {
 	m.onPrepareRename = f
 }
+
 
 func (m *Methods) prepareRename(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.PrepareRenameParams)
@@ -1017,15 +1121,16 @@ func (m *Methods) prepareRename(ctx context.Context, req interface{}) (interface
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) prepareRenameMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onPrepareRename == nil {
+    if m.onPrepareRename == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/rename",
 		NewRequest: func() interface{} {
 			return &defines.PrepareRenameParams{}
@@ -1034,9 +1139,11 @@ func (m *Methods) prepareRenameMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDocumentLinks(f func(ctx context.Context, req *defines.DocumentLinkParams) (result *[]defines.DocumentLink, err error)) {
 	m.onDocumentLinks = f
 }
+
 
 func (m *Methods) documentLinks(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DocumentLinkParams)
@@ -1045,15 +1152,16 @@ func (m *Methods) documentLinks(ctx context.Context, req interface{}) (interface
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) documentLinksMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDocumentLinks == nil {
+    if m.onDocumentLinks == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/documentLink",
 		NewRequest: func() interface{} {
 			return &defines.DocumentLinkParams{}
@@ -1062,9 +1170,11 @@ func (m *Methods) documentLinksMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDocumentLinkResolve(f func(ctx context.Context, req *defines.DocumentLink) (result *defines.DocumentLink, err error)) {
 	m.onDocumentLinkResolve = f
 }
+
 
 func (m *Methods) documentLinkResolve(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DocumentLink)
@@ -1073,15 +1183,16 @@ func (m *Methods) documentLinkResolve(ctx context.Context, req interface{}) (int
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) documentLinkResolveMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDocumentLinkResolve == nil {
+    if m.onDocumentLinkResolve == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "documentLink/resolve",
 		NewRequest: func() interface{} {
 			return &defines.DocumentLink{}
@@ -1090,9 +1201,11 @@ func (m *Methods) documentLinkResolveMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnDocumentColor(f func(ctx context.Context, req *defines.DocumentColorParams) (result *[]defines.ColorInformation, err error)) {
 	m.onDocumentColor = f
 }
+
 
 func (m *Methods) documentColor(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.DocumentColorParams)
@@ -1101,15 +1214,16 @@ func (m *Methods) documentColor(ctx context.Context, req interface{}) (interface
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) documentColorMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onDocumentColor == nil {
+    if m.onDocumentColor == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/documentColor",
 		NewRequest: func() interface{} {
 			return &defines.DocumentColorParams{}
@@ -1118,9 +1232,11 @@ func (m *Methods) documentColorMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnColorPresentation(f func(ctx context.Context, req *defines.ColorPresentationParams) (result *[]defines.ColorPresentation, err error)) {
 	m.onColorPresentation = f
 }
+
 
 func (m *Methods) colorPresentation(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.ColorPresentationParams)
@@ -1129,15 +1245,16 @@ func (m *Methods) colorPresentation(ctx context.Context, req interface{}) (inter
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) colorPresentationMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onColorPresentation == nil {
+    if m.onColorPresentation == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/colorPresentation",
 		NewRequest: func() interface{} {
 			return &defines.ColorPresentationParams{}
@@ -1146,9 +1263,11 @@ func (m *Methods) colorPresentationMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnFoldingRanges(f func(ctx context.Context, req *defines.FoldingRangeParams) (result *[]defines.FoldingRange, err error)) {
 	m.onFoldingRanges = f
 }
+
 
 func (m *Methods) foldingRanges(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.FoldingRangeParams)
@@ -1157,15 +1276,16 @@ func (m *Methods) foldingRanges(ctx context.Context, req interface{}) (interface
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) foldingRangesMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onFoldingRanges == nil {
+    if m.onFoldingRanges == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/foldingRange",
 		NewRequest: func() interface{} {
 			return &defines.FoldingRangeParams{}
@@ -1174,9 +1294,11 @@ func (m *Methods) foldingRangesMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) OnSelectionRanges(f func(ctx context.Context, req *defines.SelectionRangeParams) (result *[]defines.SelectionRange, err error)) {
 	m.onSelectionRanges = f
 }
+
 
 func (m *Methods) selectionRanges(ctx context.Context, req interface{}) (interface{}, error) {
 	params := req.(*defines.SelectionRangeParams)
@@ -1185,15 +1307,16 @@ func (m *Methods) selectionRanges(ctx context.Context, req interface{}) (interfa
 		e := wrapErrorToRespError(err, 0)
 		return res, e
 	}
-	return nil, nil
+    return nil, nil
 }
+
 
 func (m *Methods) selectionRangesMethodInfo() *jsonrpc.MethodInfo {
 
-	if m.onSelectionRanges == nil {
+    if m.onSelectionRanges == nil{
 		return nil
-	}
-	return &jsonrpc.MethodInfo{
+	}	
+    return &jsonrpc.MethodInfo{
 		Name: "textDocument/selectionRange",
 		NewRequest: func() interface{} {
 			return &defines.SelectionRangeParams{}
@@ -1202,48 +1325,49 @@ func (m *Methods) selectionRangesMethodInfo() *jsonrpc.MethodInfo {
 	}
 }
 
+
 func (m *Methods) GetMethods() []*jsonrpc.MethodInfo {
 	return []*jsonrpc.MethodInfo{
-		m.initializeMethodInfo(),
-		m.initializedMethodInfo(),
-		m.shutdownMethodInfo(),
-		m.exitMethodInfo(),
-		m.didChangeConfigurationMethodInfo(),
-		m.didChangeWatchedFilesMethodInfo(),
-		m.didOpenTextDocumentMethodInfo(),
-		m.didChangeTextDocumentMethodInfo(),
-		m.didCloseTextDocumentMethodInfo(),
-		m.willSaveTextDocumentMethodInfo(),
-		m.didSaveTextDocumentMethodInfo(),
-		m.executeCommandMethodInfo(),
-		m.hoverMethodInfo(),
-		m.completionMethodInfo(),
-		m.completionResolveMethodInfo(),
-		m.signatureHelpMethodInfo(),
-		m.declarationMethodInfo(),
-		m.definitionMethodInfo(),
-		m.typeDefinitionMethodInfo(),
-		m.implementationMethodInfo(),
-		m.referencesMethodInfo(),
-		m.documentHighlightMethodInfo(),
-		m.documentSymbolWithSliceDocumentSymbolMethodInfo(),
-		m.documentSymbolWithSliceSymbolInformationMethodInfo(),
-		m.workspaceSymbolMethodInfo(),
-		m.codeActionWithSliceCommandMethodInfo(),
-		m.codeActionWithSliceCodeActionMethodInfo(),
-		m.codeActionResolveMethodInfo(),
-		m.codeLensMethodInfo(),
-		m.codeLensResolveMethodInfo(),
-		m.documentFormattingMethodInfo(),
-		m.documentRangeFormattingMethodInfo(),
-		m.documentOnTypeFormattingMethodInfo(),
-		m.renameRequestMethodInfo(),
-		m.prepareRenameMethodInfo(),
-		m.documentLinksMethodInfo(),
-		m.documentLinkResolveMethodInfo(),
-		m.documentColorMethodInfo(),
-		m.colorPresentationMethodInfo(),
-		m.foldingRangesMethodInfo(),
-		m.selectionRangesMethodInfo(),
+	    m.initializeMethodInfo(),
+	    m.initializedMethodInfo(),
+	    m.shutdownMethodInfo(),
+	    m.exitMethodInfo(),
+	    m.didChangeConfigurationMethodInfo(),
+	    m.didChangeWatchedFilesMethodInfo(),
+	    m.didOpenTextDocumentMethodInfo(),
+	    m.didChangeTextDocumentMethodInfo(),
+	    m.didCloseTextDocumentMethodInfo(),
+	    m.willSaveTextDocumentMethodInfo(),
+	    m.didSaveTextDocumentMethodInfo(),
+	    m.executeCommandMethodInfo(),
+	    m.hoverMethodInfo(),
+	    m.completionMethodInfo(),
+	    m.completionResolveMethodInfo(),
+	    m.signatureHelpMethodInfo(),
+	    m.declarationMethodInfo(),
+	    m.definitionMethodInfo(),
+	    m.typeDefinitionMethodInfo(),
+	    m.implementationMethodInfo(),
+	    m.referencesMethodInfo(),
+	    m.documentHighlightMethodInfo(),
+	    m.documentSymbolWithSliceDocumentSymbolMethodInfo(),
+	    m.documentSymbolWithSliceSymbolInformationMethodInfo(),
+	    m.workspaceSymbolMethodInfo(),
+	    m.codeActionWithSliceCommandMethodInfo(),
+	    m.codeActionWithSliceCodeActionMethodInfo(),
+	    m.codeActionResolveMethodInfo(),
+	    m.codeLensMethodInfo(),
+	    m.codeLensResolveMethodInfo(),
+	    m.documentFormattingMethodInfo(),
+	    m.documentRangeFormattingMethodInfo(),
+	    m.documentOnTypeFormattingMethodInfo(),
+	    m.renameRequestMethodInfo(),
+	    m.prepareRenameMethodInfo(),
+	    m.documentLinksMethodInfo(),
+	    m.documentLinkResolveMethodInfo(),
+	    m.documentColorMethodInfo(),
+	    m.colorPresentationMethodInfo(),
+	    m.foldingRangesMethodInfo(),
+	    m.selectionRangesMethodInfo(),
 	}
 }

--- a/go-lsp/lsp/methods_gen_test.go
+++ b/go-lsp/lsp/methods_gen_test.go
@@ -220,7 +220,16 @@ func generate(items []method) string {
 			}
 		}
 	}
-	pkg := "// code gen by methods_gen_test.go, do not edit!\npackage lsp\n"
+	pkg := `// code gen by methods_gen_test.go, do not edit!
+package lsp
+
+import (
+	"context"
+
+	"github.com/lasorda/protobuf-language-server/go-lsp/jsonrpc"
+	"github.com/lasorda/protobuf-language-server/go-lsp/lsp/defines"
+)
+`
 	code1 := strings.Join(codeBlock1, "\n")
 	code2 := strings.Join(codeBlock2, "\n")
 	code3 := strings.Join(codeBlock3, "\n")

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func main() {
 	view.Init(server)
 	server.OnDocumentSymbolWithSliceDocumentSymbol(components.ProvideDocumentSymbol)
 	server.OnDefinition(components.JumpDefine)
+	server.OnReferences(components.FindReferences)
 	server.OnDocumentFormatting(components.Format)
 	server.OnCompletion(components.Completion)
 	server.OnHover(components.Hover)


### PR DESCRIPTION
Find References                                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                            
  Problem                                                                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                            
  The protobuf-language-server currently supports "Go to Definition" functionality, allowing users to navigate from a type usage to its definition. However, it lacks the inverse operation - there's no way to find all places where a message or enum type is used across the codebase. This makes refactoring difficult, as developers have no easy way to understand the impact of changing a type definition.                          
                                                                                                                                                                                                                                                                                                                                                                                                                                            
  Solution                                                                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                            
  This PR implements the LSP textDocument/references method, enabling "Find All References" functionality in editors that support the Language Server Protocol.    